### PR TITLE
Types/Dual-Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,119 +1,105 @@
-# Package Mode Proposal
+# Package Type Proposal
 
 This is a [Phase 2 proposal](https://github.com/nodejs/modules/blob/master/doc/plan-for-new-modules-implementation.md#phase-2) for the Node.js [ECMAScript modules project](https://github.com/nodejs/ecmascript-modules).
 
 It builds on and is complementary to Phase 2 work currently done with the [Node import file specifier resolution proposal](https://github.com/GeoffreyBooth/node-import-file-specifier-resolution-proposal) and the [package export maps proposal](https://github.com/jkrems/proposal-pkg-exports).
 
-## Problem Statement
+## Goals
 
-To provide a simple mechanism for supporting `.js` ES Modules in Node.js.
+This proposal aims to define the configuration in `package.json` that will be used to:
 
-## Current Status
+- Specify the package type, which for the most part will correspond with its intended method of consumption or target environment: CommonJS, ESM, browser, etc.
+	- A package can be multiple types.
+	- An ESM package type tells Node to treat the package’s `.js` files as ESM.
+- Specify the entry point and/or exported paths for each of a package’s types.
 
-### Example of `"exports"` as the Mode Boundary
+## Motivation
 
-The [Node import file specifier resolution proposal](https://github.com/GeoffreyBooth/node-import-file-specifier-resolution-proposal) and the [package export maps proposal](https://github.com/jkrems/proposal-pkg-exports) allow `.js` files as ESM whenever the `"exports"` property is used in a package.
+### `"exports"` as the ESM Signifier
 
-`"exports"` therefore acts as a package ESM signifier in the file import specifier proposal:
+The [Node import file specifier resolution proposal](https://github.com/GeoffreyBooth/node-import-file-specifier-resolution-proposal) and the [package export maps proposal](https://github.com/jkrems/proposal-pkg-exports) allow `.js` files as ESM whenever the `"exports"` property is used in a `package.json`. `"exports"` therefore acts as a package ESM signifier in the file import specifier proposal.
 
-_package.json_
+A `package.json` of simply `{}` will cause `node file.js` inside the same folder to load `file.js` as CommonJS.
 
-```json
-{}
-```
+However, if one then sets that `package.json` to be `{ "exports": "./file.js" }`, then `node file.js` will now load `file.js` as an ES module, while also locking down the package subpaths.
 
-will cause `node file.js` inside the same folder to load `file.js` as CommonJS.
-
-If I then set:
-
-_package.json_
-
-```json
-{
-  "exports": "./file.js"
-}
-```
-
-then `node file.js` will now load `file.js` as an ES module, while also locking down the package subpaths.
-
-### `"exports"` Mode Boundary as a Conflation of Concerns
-
-This is a conflation of three separate concerns:
-
-1. A user wants to load `.js` files within a package as ESM.
-2. A user wants to set the ESM package entry point.
-3. A user wants package export maps or encapsulation.
-
-If a user wants to achieve just one of the above, they are immediately tied into the others.
-
-Instead we should try to break up these cases into the simplest orthogonal primitives so that they are easy to understand and don't unnecessarily bundle up concerns for users.
+Users should be able to trigger `.js`-as-ESM without necessarily needing to also enable `"exports"`’ encapsulation, or needing to type the verbose `{ "exports": { "./": "./" } }`.
 
 ## Proposal
 
-The proposal, as presented before one year ago to this group (in 5 mins!), is to introduce the `"mode": "esm"` package boundary indicator
-to know when `.js` files should be treated as ESM.
+### `"type"` Field
 
-_package.json_
-
-```json
-{}
-```
-
-will load `file.js` in the same folder as CommonJS.
-
-_packge.json_
+We propose the creation of a `package.json` `type` field that takes a string or array of strings, for example:
 
 ```json
 {
-  "mode": "esm"
+  "type": "esm"
 }
 ```
-
-will now load `file.js` as an ES module.
-
-Thus a user can now achieve (1), `.js` as ESM, without necessarily opting in to the other features.
-
-### ESM entry point
-
-When it comes to setting the entry point, `"mode": "esm"` is actually fully compatible with the existing `"main"` property in the `package.json`.
-
-So instead of `{ "exports": "./file.js" }` a user can write:
 
 ```json
 {
-  "mode": "esm",
-  "main": "file.js"
+  "type": ["esm", "commonjs", "browser"]
 }
 ```
 
-to have a `.js` main ES module be supported.
+Node will initially only support the types `"esm"` and `"commonjs"`. Other types that users may specify can be used by build tools or loaders. For example, a loader could be written to enable support for a `"browser"` type by emulating a DOM environment and supplying `window` and other browser globals.
 
-If they wrote `{ "main": "file.mjs" }` then they can still have ESM support fine without setting a mode boundary.
+A `package.json` without a `type` field is equivalent to `"type": "commonjs"`. This corresponds with Node’s current behavior for loading packages.
 
-Thus (2), defining the ESM package entry point, is now fully separated as well.
+A `package.json` with `"type": "esm"` will cause Node to treat the package as ESM: not only will `.js` files within the package be loaded as ESM, but the CommonJS globals such as `__filename` etc. will not be available.
 
-### Compatibility with the Package Exports Proposal
+### Exports
 
-In terms of bringing back the `"exports"` proposal here, this can be done in a compatible way to provide package export maps and encapsulation, and possibly even dual mode package support too.
+The `"exports"` key from the [package export maps proposal](https://github.com/jkrems/proposal-pkg-exports) behaves as that proposal describes, however a package with multiple types can have objects as values:
 
-There are some implementation questions that would need to be worked out further:
+```json
+{
+  "type": ["esm", "commonjs"],
+  "exports": {
+    "./": {
+      "esm": "./src/",
+      "commonjs": "./dist/"
+    }
+  }
+}
+```
 
-* Should `"exports"` automatically act as if `"mode": "esm"` is present?
-* If there is both a `"main"` and an `"exports"` property does `"exports"` always win?
+If a path is given only one value, such as `"./": "./"`, it is applied for all of the package’s types.
+
+Note that if a package has only one type, there is no need for the object form as shown here; the simpler `".": "./src/index.js"` is enough.
+
+### Entry points
+
+`"main"` remains reserved exclusively for defining the CommonJS entry point. We cannot change its signature, for example to accept an object of multiple entry points, without breaking backward compatibility.
+
+Therefore, entry points must be defined within `"exports"`:
+
+```json
+{
+  "type": "esm",
+  "exports": "./index.mjs"
+}
+```
+```json
+{
+  "type": ["typescript", "esm", "commonjs"],
+  "exports": {
+    ".": {
+      "typescript": "./src/index.ts",
+      "esm": "./esm/index.js",
+      "commonjs": "./cjs/index.js"
+    }
+  }
+}
+```
+
+If the user wants to additionally support older versions of Node, `"main"` must also be specified. For newer versions of Node that support both `"exports"` and `"main"`, the entry point specified in `"exports"` shall take precedence.
 
 ## Specification
 
-The specification for this feature is defined here - https://github.com/guybedford/ecmascript-modules/commit/25b493c369cb430b4eac3a69ecdabe7e6cdc41c3.
-
-This is a diff on top of the current import file specifier resolution proposal spec is available at https://github.com/nodejs/ecmascript-modules/pull/19.
-
-All the defined behaviours remain, except for:
-
-1. Delegating the mode to the `"mode": "esm"` signifier.
-2. Supporting the package.json `"main"` as the main entry point in ESM packages.
+TBD.
 
 ### Draft Implementation
 
-A draft implementation of the approach is available at https://github.com/guybedford/node/tree/irp-mode-implementation.
-
-This does not yet provide the package export maps proposal support as the exact behaviours of this interaction still need to be worked out.
+TBD.

--- a/README.md
+++ b/README.md
@@ -6,40 +6,42 @@ It builds on and is complementary to Phase 2 work currently done with the [Node 
 
 ## Problem Statement
 
-To provide a simple mechanism for supporting ".js" ES Modules in Node.js.
+To provide a simple mechanism for supporting `.js` ES Modules in Node.js.
 
 ## Current Status
 
-### Example of "exports" as the Mode Boundary
+### Example of `"exports"` as the Mode Boundary
 
-The [Node import file specifier resolution proposal](https://github.com/GeoffreyBooth/node-import-file-specifier-resolution-proposal) and the [package export maps proposal](https://github.com/jkrems/proposal-pkg-exports) allow `".js"` files as ESM whenever the `"exports"` property is used in a package.
+The [Node import file specifier resolution proposal](https://github.com/GeoffreyBooth/node-import-file-specifier-resolution-proposal) and the [package export maps proposal](https://github.com/jkrems/proposal-pkg-exports) allow `.js` files as ESM whenever the `"exports"` property is used in a package.
 
-`"exports"` therefore acts as a mode boundary in the file import specifier proposal:
+`"exports"` therefore acts as a package ESM signifier in the file import specifier proposal:
 
 _package.json_
+
 ```json
 {}
 ```
 
-will load `file.js` inside the same folder as CommonJS.
+will cause `node file.js` inside the same folder to load `file.js` as CommonJS.
 
 If I then set:
 
 _package.json_
+
 ```json
 {
-  "exports": "file.js"
+  "exports": "./file.js"
 }
 ```
 
-then `file.js` will now load as an ES module, while also locking down the package subpaths.
+then `node file.js` will now load `file.js` as an ES module, while also locking down the package subpaths.
 
-### "exports" Mode Boundary as a Conflation of Concerns
+### `"exports"` Mode Boundary as a Conflation of Concerns
 
 This is a conflation of three separate concerns:
 
-1. A user wants to load a `".js"` file as ESM.
-2. A user wants to set the ES module entry point.
+1. A user wants to load `.js` files within a package as ESM.
+2. A user wants to set the ESM package entry point.
 3. A user wants package export maps or encapsulation.
 
 If a user wants to achieve just one of the above, they are immediately tied into the others.
@@ -49,9 +51,10 @@ Instead we should try to break up these cases into the simplest orthogonal primi
 ## Proposal
 
 The proposal, as presented before one year ago to this group (in 5 mins!), is to introduce the `"mode": "esm"` package boundary indicator
-to know when `".js"` files should be treated as ESM.
+to know when `.js` files should be treated as ESM.
 
 _package.json_
+
 ```json
 {}
 ```
@@ -59,6 +62,7 @@ _package.json_
 will load `file.js` in the same folder as CommonJS.
 
 _packge.json_
+
 ```json
 {
   "mode": "esm"
@@ -67,13 +71,13 @@ _packge.json_
 
 will now load `file.js` as an ES module.
 
-Thus a user can now achieve (1) without forcing unnecessary opting-in of other features.
+Thus a user can now achieve (1), `.js` as ESM, without necessarily opting in to the other features.
 
-### ESM main
+### ESM entry point
 
-When it comes to setting the main, `"mode": "esm"` is actually fully compatible with the existing `"main"` property in the package.json.
+When it comes to setting the entry point, `"mode": "esm"` is actually fully compatible with the existing `"main"` property in the `package.json`.
 
-So instead of `{ "exports": "file.js" }` a user can write:
+So instead of `{ "exports": "./file.js" }` a user can write:
 
 ```json
 {
@@ -82,16 +86,15 @@ So instead of `{ "exports": "file.js" }` a user can write:
 }
 ```
 
-to have a `".js"` main ES module be supported.
+to have a `.js` main ES module be supported.
 
 If they wrote `{ "main": "file.mjs" }` then they can still have ESM support fine without setting a mode boundary.
 
-Thus (2) is now fully separated as well.
+Thus (2), defining the ESM package entry point, is now fully separated as well.
 
-### Compatibility with the Exports Proposal
+### Compatibility with the Package Exports Proposal
 
-In terms of bringing back the "exports" proposal here, this can be done in a compatible way to
-provide package export maps and encapsulation, and possibly even dual mode package support too.
+In terms of bringing back the `"exports"` proposal here, this can be done in a compatible way to provide package export maps and encapsulation, and possibly even dual mode package support too.
 
 There are some implementation questions that would need to be worked out further:
 
@@ -106,7 +109,7 @@ This is a diff on top of the current import file specifier resolution proposal s
 
 All the defined behaviours remain, except for:
 
-1. Delegating the mode to the `"mode": "esm"` signifier
+1. Delegating the mode to the `"mode": "esm"` signifier.
 2. Supporting the package.json `"main"` as the main entry point in ESM packages.
 
 ### Draft Implementation


### PR DESCRIPTION
Readable version: https://github.com/guybedford/ecmascript-modules-mode/tree/types

So I started rewriting the proposal to both incorporate the ideas from #2 (the concept of a “package type”) and to describe how this configuration could work for a package with multiple types, such as the most common example a “dual-mode” CommonJS and ESM package. Whether or not you want to keep the “type” language, I ran into an issue with trying to make dual-mode work: `"main"`.

We can’t change `"main"`. We can’t say that going forward, `"main"` can take an object like `"main": { "esm": "./index.mjs", "cjs": "./index.js" }`. That would be a breaking change, and the whole point of supporting CommonJS as a target environment is to support older versions of Node that can’t import ESM.

So either we accept that we’re conflating two of @guybedford’s three concerns—the package entry point (main) and the package exports (encapsulation)—or we need to introduce a _new_ key to replace `"main"`. For the purposes of this proposal I opted to roll up the entry point as part of `"exports"`, the way that the package exports proposal describes it, and the object form is supported: `"exports": { ".": { "esm": "./src/index.js", "commonjs": "./dist/index.js" } }`. I think package exports and the package main entry point are very close if not joined concepts, as the entry point is basically the `/` export and the others are the `/path` exports, so I can see users grasping them as part of the same configuration block.

Alternatively, we could introduce a new key to replace `"main"`, like `"entrypoint"`. This could take the object form, like `"entrypoint": { "esm": "./src/index.js", "commonjs": "./dist/index.js" }`. Then we would still get the full separation of concerns that Guy was after, albeit with duplication as now the user can specify the entry point in either this new field or in `"exports"`. But I’m not sure we should be giving the user two places to define the same thing, and I don’t think we should take it out of `"exports"` as the entry point really is the _main_ export.

I don’t think we should assume that most packages will have only a single type/mode, and therefore it’s okay to keep using `main`. I think CommonJS/ESM dual-mode packages will be quite common for a few years, and whatever configuration we come up with should work well for such packages. Using `main` also raises the question of whether it supports automatic extensions and folder lookups (`"main": "./index"`, or `"main": "./dist/"`) for ESM or other non-CommonJS environments. It would be inconsistent either way—inconsistent if it _does_ allow such things, as then this behaves differently from `"exports"` and `import` statements; and inconsistent if it doesn’t, as then `"main"` behaves uniquely for CommonJS as opposed to other environments. I think it’s best to just leave `"main"` as a CommonJS-only legacy thing, not to be further abused.